### PR TITLE
feat(contract): donate and withdraw on each tokens

### DIFF
--- a/contract/contracts/PMToken.sol
+++ b/contract/contracts/PMToken.sol
@@ -57,13 +57,12 @@ contract PMToken is ERC721, ERC721Enumerable, ERC721URIStorage, ERC721Burnable, 
         return super.supportsInterface(interfaceId);
     }
 
-    //function to donate funds to the token
 	function donateToToken(uint tokenId) public payable {
         require(_exists(tokenId), "Token not exists");
         _donateToToken(tokenId);
     }
 
-	function _donateToToken(uint tokenId) internal {
+    function _donateToToken(uint tokenId) internal {
         balancePerToken[tokenId] = balancePerToken[tokenId] + msg.value;
     }
 

--- a/contract/contracts/PMToken.sol
+++ b/contract/contracts/PMToken.sol
@@ -10,7 +10,9 @@ import "@openzeppelin/contracts/utils/Counters.sol";
 
 contract PMToken is ERC721, ERC721Enumerable, ERC721URIStorage, ERC721Burnable, Ownable {
     using Counters for Counters.Counter;
-    mapping(address => uint) public lockTime;
+    mapping(address => mapping(uint => uint)) public lockTimeOfToken;
+    mapping(uint => uint) public balancePerToken;
+    mapping(uint => uint) public distributeNumPerToken;
 
     Counters.Counter private _tokenIdCounter;
 
@@ -21,6 +23,7 @@ contract PMToken is ERC721, ERC721Enumerable, ERC721URIStorage, ERC721Burnable, 
         _tokenIdCounter.increment();
         _safeMint(to, tokenId);
         _setTokenURI(tokenId, uri);
+        distributeNumPerToken[tokenId] = 100;
     }
 
     // The following functions are overrides required by Solidity.
@@ -54,18 +57,49 @@ contract PMToken is ERC721, ERC721Enumerable, ERC721URIStorage, ERC721Burnable, 
         return super.supportsInterface(interfaceId);
     }
 
-   //function to donate funds to the faucet contract
-	function donateTofaucet() public payable {
-	}
+    //function to donate funds to the token
+	function donateToToken(uint tokenId) public payable {
+        require(_exists(tokenId), "Token not exists");
+        _donateToToken(tokenId);
+    }
+
+	function _donateToToken(uint tokenId) internal {
+        balancePerToken[tokenId] = balancePerToken[tokenId] + msg.value;
+    }
+
+    function withdrawFromToken(uint tokenId) public payable {
+        require(_exists(tokenId), "Token not exists");
+        require(block.timestamp > lockTimeOfToken[msg.sender][tokenId], "lock time has not expired. Please try again later");
+        uint amount = balancePerToken[tokenId] / distributeNumPerToken[tokenId];
+        require(balancePerToken[tokenId] >= amount, "Not enough funds in the token. donate required");
+        Address.sendValue(payable(msg.sender), amount);
+        balancePerToken[tokenId] = balancePerToken[tokenId] - amount;
+        lockTimeOfToken[msg.sender][tokenId] = block.timestamp + 10 days;
+    }
+
+    function setDistoributeNum(uint tokenId, uint num) public {
+        require(_exists(tokenId), "Token not exists");
+        require(_isOwner(msg.sender, tokenId), "Caller is not token owner");
+        // TODO: import safeMath
+        require(num > 0, "Num must be greater than 0");
+        _setDistributeNum(tokenId, num);
+    }
+
+    function _setDistributeNum(uint tokenId, uint num) internal {
+        distributeNumPerToken[tokenId] = num;
+    }
+
+    function getBalanceOfToken(uint tokenId) public view returns(uint) {
+        require(_exists(tokenId), "Token not exists");
+        return balancePerToken[tokenId];
+    }
 
     function getBalance() public view returns(uint) {
         return address(this).balance;
     }
 
-    function faucet(uint amount) public payable {
-        require(block.timestamp > lockTime[msg.sender], "lock time has not expired. Please try again later");
-        require(address(this).balance > amount, "Not enough funds in the contract. donate required");
-        Address.sendValue(payable(msg.sender), amount);
-        lockTime[msg.sender] = block.timestamp + 10 minutes;
+    function _isOwner(address spender, uint256 tokenId) internal view returns (bool) {
+        address owner = ERC721.ownerOf(tokenId);
+        return spender == owner;
     }
 }


### PR DESCRIPTION
トークンごとにデポジット、寄付、分配率の決定を可能にする

下記の仕様で実装

```
1トークンからの報酬受け取りは、一度行うと規定の時間（とりあえず10日間）できなくなる
別のトークンからは受け取れるので、ユーザーは新しいトークンを探すことが目的になる

トークンに寄付した金額の残高 / 分配設定（デフォルト100)の金額が、アクセス者に支払われる
トークンの持ち主だけは分配率を変更できる

100ethの寄付をしたトークンの分配設定を10にすると
100 => 90 => 81 => 72.9...と減っていく
（もうちょい複雑な計算ロジックを検討したが、いつでも追加寄付を受けたいことを考えるとこれがシンプル）

寄付はトークンの持ち主以外でも行うことができる
```