### PR TITLE
コンテンツURL設定スクリプトの配置

### DIFF
--- a/contract/package.json
+++ b/contract/package.json
@@ -7,7 +7,8 @@
     "deploy:mumbai": "hardhat run scripts/deploy.ts --network mumbai",
     "debug:mint": "hardhat run scripts/mint.ts --network localhost",
     "debug:mint:mumbai": "hardhat run scripts/mint.ts --network mumbai",
-    "debug:burn:mumbai": "hardhat run scripts/burn.ts --network mumbai"
+    "debug:burn:mumbai": "hardhat run scripts/burn.ts --network mumbai",
+    "debug:seturl:mumbai": "hardhat run scripts/setURL.ts --network mumbai"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^2.0.0",

--- a/contract/scripts/setURL.ts
+++ b/contract/scripts/setURL.ts
@@ -1,0 +1,26 @@
+import { ethers } from "hardhat";
+
+const contractAddress = '0x250ad80574bf9733713A8cB38769F91264D7C5e1'
+
+async function main() {
+  const PMT = await ethers.getContractFactory("PMToken");
+  const token = await PMT.attach(contractAddress)
+
+  // oroginal songs
+  const urls = ['https://www.youtube.com/watch?v=5iXU2oxTQJk', 'https://www.youtube.com/watch?v=ngt7PGF1kys', 'https://www.youtube.com/watch?v=cdUz2xwkVak']
+  
+  const donateAmount = 100000
+  const tokenIdStart = 0
+  const tokenIdEnd = 2
+  for (let i = tokenIdStart; i <=tokenIdEnd; i++) {
+    const log = await token.setContentURI(i, urls[i % 3], { value: donateAmount})
+    console.log(`token ${i} setURL ${log.hash} url ${urls[i % 3]}`);
+  }
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
トークンに楽曲URLをまとめて設定するツールを実装しました

## 使い方

```
cd contract
export PROVATE_KEY='自分のprivate key'
npm run debug:seturl:mumbai
```

使用するときは
contract/scripts/setURL.ts
に記載の設定対象のトークンID、URL、寄付金額などを適宜変更してください

スクリプト実行前に　https://mumbaifaucet.com/　などでガス代を調達してください